### PR TITLE
add cross compilation and Android (NDK) build support

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,26 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := jpnevulator
+
+# we need at least API level 21 for posix_openpt
+TARGET_PLATFORM := android-21
+
+LOCAL_CFLAGS += -Wall
+
+LOCAL_SRC_FILES := main.c \
+	options.c \
+	jpnevulator.c \
+	byte.c \
+	interface.c \
+	tty.c \
+	pty.c \
+	io.c \
+	checksum.c \
+	crc16.c \
+	crc8.c \
+	list.c \
+	misc.c
+
+include $(BUILD_EXECUTABLE)

--- a/INSTALL
+++ b/INSTALL
@@ -25,6 +25,9 @@ Compiling
 After this make you will have a binary called jpnevulator in the main source
 directory. You can copy this binary everywhere you like.
 
+You can also pass CC=cross-compile-gcc to the make command to build with a
+different compiler (for example to cross-compile jpnevulator) than gcc.
+
 Android binary
 ==============
 

--- a/INSTALL
+++ b/INSTALL
@@ -25,4 +25,9 @@ Compiling
 After this make you will have a binary called jpnevulator in the main source
 directory. You can copy this binary everywhere you like.
 
+Android binary
+==============
 
+	$ ndk-build APP_PLATFORM=android-21 APP_BUILD_SCRIPT=Android.mk NDK_PROJECT_PATH=.
+
+After this the resulting binaries can be found in libs/<platform>/jpnevulator

--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,10 @@ OBJECTS+=misc.o
 MANPAGES=jpnevulator.1.gz
 
 # Tools 
-CLIBS=
-CFLAGS=-Wall
-LDFLAGS=
-CC=gcc
+CLIBS?=
+CFLAGS+=-Wall
+LDFLAGS?=
+CC?=gcc
 GZIP=gzip
 INSTALL=install
 


### PR DESCRIPTION
I wanted to sniff some data on an Android based device
unfortunately I couldn't get the original sources to cross-compile

after I got it cross-compiling I found out that the result didn't work on my device
so I went one step further and added Android NDK build support

please decide yourself if you consider this useful or not