### PR TITLE
Flush output stream after printing state of control lines.

### DIFF
--- a/tty.c
+++ b/tty.c
@@ -56,6 +56,7 @@ static void ttyControlWrite(FILE *output,int control) {
 		control&TIOCM_RI?1:0,
 		control&TIOCM_DSR?1:0
 	);
+	fflush(output);
 }
 
 static void ttyClose(int fd) {


### PR DESCRIPTION
Lack of stdout flushing after printing state of control lines causes unpredictable delays when we are going to redirect stdout to file or use pipe to next process.
Testing: 
env: Linux Debian bookworm/sid 5.14.0-2-amd64 #1 SMP Debian 5.14.9-2 (2021-10-03) x86_64 GNU/Linux
prereq: USB serial converter or phy serial port

Run  ```./jpnevulator -t /dev/ttyUSB0 -r -C -g - S -a 1>1.txt```, next after 3-5 seconds kill it with ctrl+c
File 1.txt should include something like:
```
2021-11-14 11:28:53.761480:
le=0, dtr=1, rts=1, st=0, sr=0, cts=0, cd=0, ri=0, dsr=0
```
1.txt file will be empty without flushing stdout.
 


